### PR TITLE
Discourage browsers from caching the authorization check

### DIFF
--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -122,6 +122,7 @@ public class Server {
 
         get("api/check-authorization", (req, res) -> {
             res.type("application/json");
+            res.header("Cache-Control","no-cache, no-store, must-revalidate");
             String cookie = req.cookie("ddg");
             Document returnDoc = new Document();
             returnDoc.append("authorized", auth.authorized(cookie));


### PR DESCRIPTION
This is an attempt to fix an issue we had with logging in on IE 11 on Windows 7.

@15sora2 if you could merge this and test it on the droplet _before_ our meeting tomorrow, that would be awesome.

Issue #2